### PR TITLE
Refactored loop code to use references when passing state objects.

### DIFF
--- a/isaac_demo/enemy.cpp
+++ b/isaac_demo/enemy.cpp
@@ -1,7 +1,7 @@
 #include "enemy.h"
 
-void draw_enemy(Arduboy2 arduboy, Enemy e){
+void draw_enemy(Arduboy2 * arduboy, Enemy * e){
 
-  arduboy.drawSlowXYBitmap(e.xpos, e.ypos, e.bmp, e.width, e.height, WHITE);
+  arduboy->drawSlowXYBitmap(e->xpos, e->ypos, e->bmp, e->width, e->height, WHITE);
 
 };

--- a/isaac_demo/enemy.h
+++ b/isaac_demo/enemy.h
@@ -26,6 +26,6 @@ typedef struct Enemy {
   int life;
 } Enemy;
 
-void draw_enemy(Arduboy2 arduboy, Enemy e);
+void draw_enemy(Arduboy2 * arduboy, Enemy * e);
 
 #endif

--- a/isaac_demo/isaac.cpp
+++ b/isaac_demo/isaac.cpp
@@ -1,21 +1,21 @@
 #include "isaac.h"
 
-void move_isaac(Arduboy2 arduboy, Isaac *isaac){
+void move_isaac(Arduboy2 * arduboy, Isaac * isaac){
 
-  if (arduboy.pressed(RIGHT_BUTTON) && isaac->xpos < WIDTH - (isaac->width + 1)) {
+  if (arduboy->pressed(RIGHT_BUTTON) && isaac->xpos < WIDTH - (isaac->width + 1)) {
     isaac->xpos += isaac->speedx;
-  }else if (arduboy.pressed(LEFT_BUTTON) && isaac->xpos > 1) {
+  }else if (arduboy->pressed(LEFT_BUTTON) && isaac->xpos > 1) {
     isaac->xpos -= isaac->speedx;
-  }else if (arduboy.pressed(DOWN_BUTTON) && isaac->ypos < HEIGHT - (isaac->height + 1)) {
+  }else if (arduboy->pressed(DOWN_BUTTON) && isaac->ypos < HEIGHT - (isaac->height + 1)) {
     isaac->ypos += isaac->speedy;
-  }else if (arduboy.pressed(UP_BUTTON) && isaac->ypos > 1) {
+  }else if (arduboy->pressed(UP_BUTTON) && isaac->ypos > 1) {
     isaac->ypos -= isaac->speedy;
   }
 
 }
 
-void draw_isaac(Arduboy2 arduboy, Isaac isaac){
+void draw_isaac(Arduboy2 * arduboy, Isaac * isaac){
 
-  arduboy.drawSlowXYBitmap(isaac.xpos, isaac.ypos, isaac.bmp, isaac.width, isaac.height, WHITE);
+  arduboy->drawSlowXYBitmap(isaac->xpos, isaac->ypos, isaac->bmp, isaac->width, isaac->height, WHITE);
 
 }

--- a/isaac_demo/isaac.h
+++ b/isaac_demo/isaac.h
@@ -21,7 +21,7 @@ typedef struct Isaac {
   int life;
 } Isaac;
 
-void move_isaac(Arduboy2, Isaac*);
-void draw_isaac(Arduboy2, Isaac);
+void draw_isaac(Arduboy2 * arduboy, Isaac * isaac);
+void move_isaac(Arduboy2 * arduboy, Isaac * isaac);
 
 #endif

--- a/isaac_demo/isaac_demo.ino
+++ b/isaac_demo/isaac_demo.ino
@@ -40,12 +40,12 @@ void loop() {
   }
   arduboy.clear();
 
-  draw_enemy(arduboy, f1);
-  draw_enemy(arduboy, p1);
-  draw_room(arduboy, r);
-  draw_isaac(arduboy, isaac);
+  draw_enemy(&arduboy, &f1);
+  draw_enemy(&arduboy, &p1);
+  draw_room(&arduboy, &r);
+  draw_isaac(&arduboy, &isaac);
   
-  move_isaac(arduboy, &isaac);
+  move_isaac(&arduboy, &isaac);
 
   arduboy.display();
 }

--- a/isaac_demo/room.cpp
+++ b/isaac_demo/room.cpp
@@ -1,26 +1,26 @@
 #include "room.h"
 
 // Draws all features of the room within the space specified.
-void draw_room(Arduboy2 arduboy, Room r) {
+void draw_room(Arduboy2 * arduboy, Room * r) {
 
   int door_width = 16;
   int door_thickness = 4;
   int top_margin = 10;
 
-  if (r.doors[0]) {
-    arduboy.fillRect(WIDTH/2 - door_width/2,
+  if (r->doors[0]) {
+    arduboy->fillRect(WIDTH/2 - door_width/2,
                top_margin + door_thickness, door_width, door_thickness, WHITE);
   }
-  if (r.doors[1]) {
-    arduboy.fillRect(WIDTH - door_thickness,
+  if (r->doors[1]) {
+    arduboy->fillRect(WIDTH - door_thickness,
                (HEIGHT - top_margin)/2 - door_width/2 + top_margin, door_thickness, door_width, WHITE);
   }
-  if (r.doors[2]) {
-    arduboy.fillRect(WIDTH/2 - door_width/2,
+  if (r->doors[2]) {
+    arduboy->fillRect(WIDTH/2 - door_width/2,
                HEIGHT - door_thickness, door_width, door_thickness, WHITE);
   }
-  if (r.doors[3]) {
-    arduboy.fillRect(0,
+  if (r->doors[3]) {
+    arduboy->fillRect(0,
                (HEIGHT - top_margin)/2 - door_width/2 + top_margin, door_thickness, door_width, WHITE);
   }
 }

--- a/isaac_demo/room.h
+++ b/isaac_demo/room.h
@@ -9,6 +9,6 @@ typedef struct Room {
   int doors[4];
 } Room;
 
-void draw_room(Arduboy2 arduboy, Room r);
+void draw_room(Arduboy2 * arduboy, Room * r);
 
 #endif


### PR DESCRIPTION
Current implementation passes actual structs of relevant state to functions during loop(), which means that memory is being doubled at most points in the loop.

An adoption of references will reduce memory usage (in an environment with enough resource constraints that this should have merit) and allow more complex features in the move/collision functions by allowing them to directly mutate object state w/out returning a whole new state structure(s) (and thereby tripling up some segments of state memory).