### PR TITLE
Updated bitmap fields in isaac/enemy to use pointers to const arrays

### DIFF
--- a/isaac_demo/enemy.h
+++ b/isaac_demo/enemy.h
@@ -22,7 +22,7 @@ typedef struct Enemy {
   int speedx;
   int speedy;
   enemy_type type; 
-  uint8_t bmp;
+  const uint8_t * bmp;
   int life;
 } Enemy;
 

--- a/isaac_demo/isaac.h
+++ b/isaac_demo/isaac.h
@@ -17,11 +17,11 @@ typedef struct Isaac {
   int width;
   int speedx;
   int speedy;
-  uint8_t bmp;
+  const uint8_t * bmp;
   int life;
 } Isaac;
 
-void move_isaac(Arduboy2, Isaac*);
-void draw_isaac(Arduboy2, Isaac);
+void draw_isaac(Arduboy2 arduboy, Isaac isaac);
+void move_isaac(Arduboy2 arduboy, Isaac * isaac);
 
 #endif


### PR DESCRIPTION
bmp field in sprite structs was a value, but it was being assigned a PROGMEM (which the compiler abstracts to a pointer type). As a result the bitmaps were not drawing as intended.

Retyping to const uint8_t * seems to remedy this.